### PR TITLE
Add fail counter to testProtos.sh

### DIFF
--- a/testProtos.sh
+++ b/testProtos.sh
@@ -17,6 +17,7 @@ eval $command
 #TOOLRUN="valgrind --leak-check=full"
 
 count=0
+failcount=0
 
 function TestProto {
 ((count++))
@@ -319,6 +320,7 @@ i=1
 while [[ $i -le $count ]]
 do
 echo ${testResult[i]}: ${testList[i]}
+if [ "${testResult[i]}" != "PASS" ]; then ((failcount++)); fi
 ((i++))
 done
 echo "== TEST SUMMARY STOP =="
@@ -327,3 +329,5 @@ date
 echo
 echo ---------------------------------------------------------------------------
 grep " ERROR " */PET*.ESMF_LogFile
+
+exit $failcount


### PR DESCRIPTION
Using `grep " ERROR "` as the last line in the script unintentionally sets the exit code to 1 if no ERROR is found.  I think it would be better to either exit with the failure count or exit 1 if any failure is found.  I can code either. I don't know if this breaks any downstream scripts.