### PR TITLE
Fix workflow cache

### DIFF
--- a/.github/workflows/develop-nightly.yml
+++ b/.github/workflows/develop-nightly.yml
@@ -35,7 +35,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{env.STACK_ROOT}}
-        key: develop-nightly-${{matrix.config.os}}-${{matrix.config.compiler}}-${{matrix.config.comm}}
+        key: develop-nightly-${{matrix.config.os}}-${{matrix.config.compiler}}-${{matrix.config.comm}}-${{github.run_id}}
+        restore-keys: |
+          develop-nightly-${{matrix.config.os}}-${{matrix.config.compiler}}-${{matrix.config.comm}}
     - name: Install OPENMPI
       if: ${{matrix.config.comm}} == 'openmpi'
       env:
@@ -102,7 +104,9 @@ jobs:
         ESMF_NETCDF: 'nc-config'
         ESMF_INSTALL_PREFIX: ${STACK_ROOT}
       with:
+        build-key: 'develop-nightly-${{matrix.config.os}}-${{matrix.config.compiler}}-${{matrix.config.comm}}'
         version: 'develop'
+        rebuild-check: quick
         esmpy: false
         cache: false
     - name: NUOPC Tests

--- a/.github/workflows/develop-nightly.yml
+++ b/.github/workflows/develop-nightly.yml
@@ -35,9 +35,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{env.STACK_ROOT}}
-        key: develop-nightly-${{matrix.config.os}}-${{matrix.config.compiler}}-${{matrix.config.comm}}-${{github.run_id}}
-        restore-keys: |
-          develop-nightly-${{matrix.config.os}}-${{matrix.config.compiler}}-${{matrix.config.comm}}
+        key: develop-nightly-${{matrix.config.os}}-${{matrix.config.compiler}}-${{matrix.config.comm}}
     - name: Install OPENMPI
       if: ${{matrix.config.comm}} == 'openmpi'
       env:
@@ -102,13 +100,12 @@ jobs:
         ESMF_COMPILER: ${{matrix.config.compiler}}
         ESMF_COMM: ${{matrix.config.comm}}
         ESMF_NETCDF: 'nc-config'
-        ESMF_INSTALL_PREFIX: ${STACK_ROOT}
       with:
         build-key: 'develop-nightly-${{matrix.config.os}}-${{matrix.config.compiler}}-${{matrix.config.comm}}'
         version: 'develop'
         rebuild-check: quick
         esmpy: false
-        cache: false
+        cache: true
     - name: NUOPC Tests
       run: |
         export TOOLRUN="--oversubscribe"


### PR DESCRIPTION
I learned that caches are immutable so this fixes that by creating a new cache every time the ESMF branch is updated. Each cache automatically deletes after 7 days of inactivity. Plus I'm using the new rebuild-check=quick, which cuts down the `install-esmf-action` for existing commits from 4 seconds to 1 second.

Merge squash when ready