### PR TITLE
Cleanup ESMX single model prototypes

### DIFF
--- a/ESMX_SingleModelInCProto/Makefile
+++ b/ESMX_SingleModelInCProto/Makefile
@@ -30,17 +30,16 @@ ESMF_INTERNAL_MPIRUN := $(shell echo $(ESMF_INTERNAL_MPIRUN))
 ################################################################################
 ################################################################################
 EXE = install/bin/esmx_app
-.PHONY: $(EXE)
+.PHONY: $(EXE) DL
 
-$(EXE):
-	$(ESMF_APPSDIR)/ESMX_Builder -v
+$(EXE): DL
 
 DL:
 	$(ESMF_APPSDIR)/ESMX_Builder -v esmxBuildDL.yaml
 
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------
-.PHONY: dust clean distclean info run
+.PHONY: dust clean distclean info run runDL
 dust:
 	rm -f PET*.ESMF_LogFile *.nc *.stdout
 clean:
@@ -54,8 +53,7 @@ info:
 	@cat $(ESMFMKFILE)
 	@echo ==================================================================
 
-run:
-	$(ESMF_INTERNAL_MPIRUN) -np 4 ./$(EXE)
+run: runDL
 
 runDL:
 	$(ESMF_INTERNAL_MPIRUN) -np 4 ./$(EXE) esmxRunDL.yaml

--- a/ESMX_SingleModelInFortranProto/Makefile
+++ b/ESMX_SingleModelInFortranProto/Makefile
@@ -30,7 +30,7 @@ ESMF_INTERNAL_MPIRUN := $(shell echo $(ESMF_INTERNAL_MPIRUN))
 ################################################################################
 ################################################################################
 EXE = install/bin/esmx_app
-.PHONY: $(EXE)
+.PHONY: $(EXE) DL
 
 $(EXE):
 	$(ESMF_APPSDIR)/ESMX_Builder -v
@@ -40,7 +40,7 @@ DL:
 
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------
-.PHONY: dust clean distclean info run
+.PHONY: dust clean distclean info run runDL
 dust:
 	rm -f PET*.ESMF_LogFile *.nc *.stdout
 clean:


### PR DESCRIPTION
Are you okay with this cleanup?

- esmxBuild.yaml and esmxRun.yaml didn't exist in ESMX_SingleModelInCProto (and it's necessary to turn off link_into_app)