### PR TITLE
ESMF_VERSION override in PR body

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Description
+<!-- Provide a brief summary of the changes introduced by this PR and which issues they fix -->
+
+Fixes # (issue)
+
+## CI Testing & ESMF Dependency Override
+By default, the CI workflow builds against the `develop` branch of ESMF. If this PR introduces functionality or structural updates that rely on a specific version, tag, or experimental branch of ESMF, you can explicitly override the baseline here.
+
+> [!TIP]
+> To change the ESMF baseline for this PR's automated runs, uncomment the line below and specify your target branch, tag, or version (e.g., `v8.5.0b23`, `v8.6.0`, or a feature branch name).
+
+<!-- ESMF_VERSION: develop -->

--- a/.github/workflows/develop-nightly.yml
+++ b/.github/workflows/develop-nightly.yml
@@ -33,9 +33,21 @@ jobs:
             comm: openmpi
           }
     env:
-      ESMF_VERSION: ${{ inputs.esmf_version || 'develop' }}
+      ESMF_VERSION: ${{ inputs.esmf_version || steps.pr_override.outputs.esmf_version || 'develop' }}
       NUOPC_APP_VERSION: ${{ inputs.nuopc_app_version || github.head_ref || 'develop' }}
     steps:
+    - name: Check PR body for ESMF version override
+      id: pr_override
+      if: github.event_name == 'pull_request'
+      run: |
+        PR_BODY="${{ github.event.pull_request.body }}"
+        VERSION_OVERRIDE=$(echo "$PR_BODY" | grep -iE 'esmf_version\s*:\s*' | head -n 1 | sed -E 's/.*esmf_version\s*:\s*([^ ]+).*/\1/' | tr -d '\r\n')
+        if [ -n "$VERSION_OVERRIDE" ]; then
+          echo "Found ESMF version override in PR body: $VERSION_OVERRIDE"
+          echo "esmf_version=$VERSION_OVERRIDE" >> $GITHUB_OUTPUT
+        else
+          echo "No ESMF version override found in PR body."
+        fi
     - name: Report ESMF and NUOPC Application Prototypes versions
       run: |
         echo "ESMF_VERSION: ${ESMF_VERSION}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/develop-nightly.yml
+++ b/.github/workflows/develop-nightly.yml
@@ -8,7 +8,7 @@ on:
       - develop
   workflow_dispatch:
     inputs:
-      esmf_version: 
+      esmf_version:
         description: 'ESMF version or tag like develop or v8.5.0b23'
         required: false
         type: string

--- a/.github/workflows/develop-nightly.yml
+++ b/.github/workflows/develop-nightly.yml
@@ -42,10 +42,10 @@ jobs:
         PR_BODY="${{ github.event.pull_request.body }}"
         VERSION_OVERRIDE=$(echo "$PR_BODY" | grep -iE 'esmf_version\s*:\s*' | head -n 1 | sed -E 's/.*esmf_version\s*:\s*([^ ]+).*/\1/' | tr -d '\r\n')
         if [ -n "$VERSION_OVERRIDE" ]; then
-          echo "Found ESMF version override in PR body: $VERSION_OVERRIDE"
+          echo "Found version override in PR body: ESMF_VERSION=$VERSION_OVERRIDE"
           echo "ESMF_VERSION=$VERSION_OVERRIDE" >> $GITHUB_ENV
         else
-          echo "No PR override found. Sticking with: $ESMF_VERSION"
+          echo "No PR override found. Sticking with: ESMF_VERSION=$ESMF_VERSION"
         fi
     - name: Report ESMF and NUOPC Application Prototypes versions
       run: |

--- a/.github/workflows/develop-nightly.yml
+++ b/.github/workflows/develop-nightly.yml
@@ -19,6 +19,10 @@ on:
         type: string
         default: 'develop'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   nuopc-test:
     name: ${{matrix.config.name}}

--- a/.github/workflows/develop-nightly.yml
+++ b/.github/workflows/develop-nightly.yml
@@ -44,7 +44,7 @@ jobs:
       if: github.event_name == 'pull_request'
       run: |
         PR_BODY="${{ github.event.pull_request.body }}"
-        VERSION_OVERRIDE=$(echo "$PR_BODY" | grep -iE 'esmf_version\s*:\s*' | head -n 1 | sed -E 's/.*esmf_version\s*:\s*([^ ]+).*/\1/' | tr -d '\r\n')
+        VERSION_OVERRIDE=$(echo "$PR_BODY" | grep -iE 'esmf_version\s*:' | head -n 1 | awk -F':' '{print $2}' | xargs)
         if [ -n "$VERSION_OVERRIDE" ]; then
           echo "Found version override in PR body: ESMF_VERSION=$VERSION_OVERRIDE"
           echo "ESMF_VERSION=$VERSION_OVERRIDE" >> $GITHUB_ENV

--- a/.github/workflows/develop-nightly.yml
+++ b/.github/workflows/develop-nightly.yml
@@ -33,20 +33,19 @@ jobs:
             comm: openmpi
           }
     env:
-      ESMF_VERSION: ${{ inputs.esmf_version || steps.pr_override.outputs.esmf_version || 'develop' }}
+      ESMF_VERSION: ${{ inputs.esmf_version || 'develop' }}
       NUOPC_APP_VERSION: ${{ inputs.nuopc_app_version || github.head_ref || 'develop' }}
     steps:
     - name: Check PR body for ESMF version override
-      id: pr_override
       if: github.event_name == 'pull_request'
       run: |
         PR_BODY="${{ github.event.pull_request.body }}"
         VERSION_OVERRIDE=$(echo "$PR_BODY" | grep -iE 'esmf_version\s*:\s*' | head -n 1 | sed -E 's/.*esmf_version\s*:\s*([^ ]+).*/\1/' | tr -d '\r\n')
         if [ -n "$VERSION_OVERRIDE" ]; then
           echo "Found ESMF version override in PR body: $VERSION_OVERRIDE"
-          echo "esmf_version=$VERSION_OVERRIDE" >> $GITHUB_OUTPUT
+          echo "ESMF_VERSION=$VERSION_OVERRIDE" >> $GITHUB_ENV
         else
-          echo "No ESMF version override found in PR body."
+          echo "No PR override found. Sticking with: $ESMF_VERSION"
         fi
     - name: Report ESMF and NUOPC Application Prototypes versions
       run: |


### PR DESCRIPTION
This PR implements a new feature that allows override of the `ESMF_VERSION=develop` default in the PR body. A PR template is also added to explain.