### PR TITLE
Fix a number of general issues identified during review

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
         PR_BODY: ${{ github.event.pull_request.body }}
       run: |
         # Strip multi-line and single-line HTML comments from PR_BODY, then search for active override
-        CLEAN_BODY=$(echo "$PR_BODY" | sed -E ':a;N;$!ba;s/<!--.*?-->//g')
+        CLEAN_BODY=$(perl -0pe 's/<!--.*?-->//gs' <<< "$PR_BODY")
         VERSION_OVERRIDE=$(grep -m 1 -iE '^\s*esmf_version\s*:' <<< "$CLEAN_BODY" | awk -F':' '{print $2}' | tr -d '\r\n' | xargs)
         
         if [ -n "$VERSION_OVERRIDE" ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,12 +66,15 @@ jobs:
       env:
         PR_BODY: ${{ github.event.pull_request.body }}
       run: |
-        VERSION_OVERRIDE=$(grep -m 1 -iE 'esmf_version\s*:' <<< "$PR_BODY" | awk -F':' '{print $2}' | tr -d '\r\n' | xargs)
+        # Strip multi-line and single-line HTML comments from PR_BODY, then search for active override
+        CLEAN_BODY=$(echo "$PR_BODY" | sed -E ':a;N;$!ba;s/<!--.*?-->//g')
+        VERSION_OVERRIDE=$(grep -m 1 -iE '^\s*esmf_version\s*:' <<< "$CLEAN_BODY" | awk -F':' '{print $2}' | tr -d '\r\n' | xargs)
+        
         if [ -n "$VERSION_OVERRIDE" ]; then
-          echo "Found version override in PR body: ESMF_VERSION=$VERSION_OVERRIDE"
+          echo "Found active version override in PR body: ESMF_VERSION=$VERSION_OVERRIDE"
           echo "ESMF_VERSION=$VERSION_OVERRIDE" >> $GITHUB_ENV
         else
-          echo "No PR override found. Sticking with: ESMF_VERSION=$ESMF_VERSION"
+          echo "No active PR override found (commented out or omitted). Sticking with: ESMF_VERSION=$ESMF_VERSION"
         fi
     - name: Report ESMF and NUOPC Application Prototypes versions
       run: |

--- a/ESMX_SingleModelInFortranCMakeProto/README.md
+++ b/ESMX_SingleModelInFortranCMakeProto/README.md
@@ -15,9 +15,8 @@ Files and sub-directories that implement the fundamental concept demonstrated by
 - `SiMoCo`            - Simple NUOPC-compliant Model Component, utilizing a CMake based build system.
 - `esmxBuild.yaml`    - Standard ESMX YAML file describing the build dependencies of the `esmx_app` (the executable) on SiMoCo via the direct linking approach.
 - `esmxRun.yaml`      - Standard ESMX YAML file describing the run configuration suitable for the direct linking approach.
-- `esmxBuildDL.yaml`- Standard ESMX YAML file describing the build dependencies of the `esmx_app` (the executable) on SiMoCo via the dynamic loading at run-time approach.
-- `esmxRunDL.yaml`  - Standard ESMX YAML file describing the run configuration suitable for the dynamic loading at run-time approach.
-- `cmake`             - Subdirectory holding the `FindESMF.cmake`. This is used by the `CMakeLists.txt` file to find and access ESMF.
+- `esmxBuildDL.yaml`  - Standard ESMX YAML file describing the build dependencies of the `esmx_app` (the executable) on SiMoCo via the dynamic loading at run-time approach.
+- `esmxRunDL.yaml`    - Standard ESMX YAML file describing the run configuration suitable for the dynamic loading at run-time approach.
 - `CMakeLists.txt`    - The top-level CMake file.
 
 ### Usage

--- a/ESMX_SingleModelInFortranScriptCMakeProto/README.md
+++ b/ESMX_SingleModelInFortranScriptCMakeProto/README.md
@@ -15,9 +15,8 @@ Files and sub-directories that implement the fundamental concept demonstrated by
 - `SiMoCo`            - Simple NUOPC-compliant Model Component, utilizing a CMake based build system.
 - `esmxBuild.yaml`    - Standard ESMX YAML file describing the build dependencies of the `esmx_app` (the executable) on SiMoCo via the direct linking approach.
 - `esmxRun.yaml`      - Standard ESMX YAML file describing the run configuration suitable for the direct linking approach.
-- `esmxBuildDL.yaml`- Standard ESMX YAML file describing the build dependencies of the `esmx_app` (the executable) on SiMoCo via the dynamic loading at run-time approach.
-- `esmxRunDL.yaml`  - Standard ESMX YAML file describing the run configuration suitable for the dynamic loading at run-time approach.
-- `cmake`             - Subdirectory holding the `FindESMF.cmake`. This is used by the `CMakeLists.txt` file to find and access ESMF.
+- `esmxBuildDL.yaml`  - Standard ESMX YAML file describing the build dependencies of the `esmx_app` (the executable) on SiMoCo via the dynamic loading at run-time approach.
+- `esmxRunDL.yaml`    - Standard ESMX YAML file describing the run configuration suitable for the dynamic loading at run-time approach.
 - `CMakeLists.txt`    - The top-level CMake file.
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # NUOPC Application Prototypes
 
-The NUOPC Application Prototypes demonstrate a wide range of features implemented by the [NUOPC](https://github.com/esmf-org/esmf/tree/develop/src/addon/NUOPC) layer. The aim of the prototypes is to provide example and template codes that are directly applicable to real world situations. The focus is on coupling through the NUOPC standards, and not on model details. For this reason *no* physically realistic model codes are included!
+The NUOPC Application Prototypes demonstrate a wide range of features implemented by the [NUOPC](https://github.com/esmf-org/esmf/tree/develop/src/addon/NUOPC) layer. The goal of these prototypes is to provide example and template code directly applicable to real-world situations. The focus is strictly on coupling through NUOPC standards rather than model details. For this reason, **no** physically realistic model codes are included!
 
-The structure of the repository is such that each top-level directory holds a self-contained prototype example. The name of the directory indicates roughly the focus or structure of the specific example itself. E.g. `AtmOcnPetListProto` is a case with two components (ATM and OCN), where the components are created on specific PET lists.
+The repository is structured so that each top-level directory contains a self-contained prototype example. Directory names broadly indicate the design pattern or focus of each case. For example, `AtmOcnPetListProto` demonstrates a system with two components (`ATM` and `OCN`) created on specific PET lists. Details for each case are provided in the `README.md` file within its respective directory.
 
-The [ESMX](https://github.com/esmf-org/esmf/tree/develop/src/addon/ESMX) layer is built on top of ESMF and NUOPC. The idea is to make it as simple as possible for a user to build, run, and test NUOPC based systems, often without having to write any extra code beyond the NUOPC-compliant models. **We strongly recommend that anybody interested in building coupled systems with NUOPC starts their journey by looking at the ESMX prototypes first!** These prototypes are easy to identify by the `ESMX_` prefix of the directory names.
+## ESMX
+
+The [ESMX](https://github.com/esmf-org/esmf/tree/develop/src/addon/ESMX) layer is built on top of ESMF and NUOPC. The goal of ESMX is to make it as simple as possible to build, run, and test NUOPC-based systems, often without having to write any code beyond the NUOPC-compliant models.
+
+**We strongly recommend that anyone interested in building coupled systems with NUOPC starts their journey by looking at the ESMX prototypes first!** These prototypes are easily identified by the `ESMX_` prefix in their directory names.
+
+## Test Environment
+
+Building and running the application prototypes requires a complete ESMF library installation. The following environment variables direct the test infrastructure:
+
+- **`ESMFMKFILE`**: Must point to the `esmf.mk` file of the ESMF installation.
+- **`CMAKE_PREFIX_PATH`**: Must contain the path to the ESMF installation root directory. Alternatively, with modern CMake, **`ESMF_ROOT`** can be set instead.

--- a/testProtos.sh
+++ b/testProtos.sh
@@ -10,8 +10,15 @@
 # Licensed under the University of Illinois-NCSA License.
 #==============================================================================
 
+# Ensure ESMFMKFILE is set and valid
+if [ -z "$ESMFMKFILE" ] || [ ! -f "$ESMFMKFILE" ]; then
+  echo "Error: ESMFMKFILE environment variable is not set or file does" \
+       "not exist." >&2
+  exit 1
+fi
+
 # Obtain ESMF_INTERNAL_MPIRUN from esmf.mk
-command=`grep ESMF_INTERNAL_MPIRUN $ESMFMKFILE`
+command=$(grep ESMF_INTERNAL_MPIRUN "$ESMFMKFILE")
 eval $command
 
 #TOOLRUN="valgrind --leak-check=full"
@@ -28,16 +35,16 @@ then
    # tests where CMake is used under the hood to determine the correct
    # compiler and linker flags. Set them here to be available.
 
-   # We'll try to get the location from a spack installation of llvm-openmp if possible,
-   # but if we can't find that, then we'll fall back on assuming that libomp is available
-   # via homebrew.
+   # We'll try to get the location from a spack installation of llvm-openmp
+   # if possible, but if we can't find that, then we'll fall back on assuming
+   # that libomp is available via homebrew.
    homebrew_libomp_dir=/opt/homebrew/opt/libomp
 
    if command -v spack &>/dev/null; then
       # First try getting these from a spack-installed llvm-openmp:
       omp_dir=$(spack location -i --first llvm-openmp 2>/dev/null)
       if [ $? -ne 0 ]; then
-         # llvm-openmp isn't installed with spack; fall back on the homebrew location
+         # llvm-openmp isn't installed with spack; fall back to homebrew location
          omp_dir=${homebrew_libomp_dir}
       fi
    else


### PR DESCRIPTION
## Description
This PR addresses the following concerns:
- Check in `testProtos.sh` that `ESMFMKFILE` is set. Resolves #20.
- Improves general documentation in `README.md`, including a section on "Test Environment" that mentions the need to either include ESMF installation location in `CMAKE_PREFIX_PATH`, or set `ESMF_ROOT` environment variables. Resolves #21.

## CI Testing & ESMF Dependency Override
By default, the CI workflow builds against the `develop` branch of ESMF. If this PR introduces functionality or structural updates that rely on a specific version, tag, or experimental branch of ESMF, you can explicitly override the baseline here.

> [!TIP]
> To change the ESMF baseline for this PR's automated runs, uncomment the line below and specify your target branch, tag, or version (e.g., `v8.5.0b23`, `v8.6.0`, or a feature branch name).

<!-- ESMF_VERSION: develop -->
